### PR TITLE
Add Golang Linear Search

### DIFF
--- a/LinearSearch/Go/linear_search.go
+++ b/LinearSearch/Go/linear_search.go
@@ -1,0 +1,13 @@
+package search
+
+// LinearSearch returns the index of the given key found on the list.
+// It returns a value of -1 if the key doesn't exist
+func LinearSearch(list []int, key int) int {
+	for index, element := range list {
+		if key == element {
+			return index
+		}
+	}
+
+	return -1
+}

--- a/LinearSearch/Go/linear_search_test.go
+++ b/LinearSearch/Go/linear_search_test.go
@@ -1,0 +1,35 @@
+package search
+
+import "testing"
+
+func TestLinearSearch(t *testing.T) {
+	var tests = []struct {
+		input  []int
+		key    int
+		output int
+	}{
+		{
+			input:  []int{1, 2, 3, 4, 5},
+			key:    3,
+			output: 2,
+		},
+		{
+			input:  []int{-1, 0, 100, 33, 44},
+			key:    -2,
+			output: -1,
+		},
+		{
+			input:  []int{},
+			output: -1,
+		},
+	}
+
+	for _, test := range tests {
+		result := LinearSearch(test.input, test.key)
+
+		if result != test.output {
+			t.Errorf("LinearSearch(%v, %v) => %v, want %v",
+				test.input, test.key, result, test.output)
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Inverse Fast Fourier Transform |  |  |  |  | :+1: |  |  |  |
 Johnson algorithm | :+1: | :+1: |  |  | :+1: |  |  |  |
 Kadane's algorithm | :+1: | :+1: |  | :+1: | :+1: | :+1: | :+1: |  |
 Knuth Morris Prath Algorithm | :+1: | :+1: |  |  | :+1: |  |  |  |
-LinearSearch | :+1: | :+1: |  |  :+1:| :+1: | :+1: |  |  |  | :+1: |
+LinearSearch | :+1: | :+1: |  |  :+1:| :+1: | :+1: | :+1: |  |  | :+1: |
 Longest-Common-Subsequence | :+1: | :+1: |  |  | :+1: |  |  |  | :+1:
 Longest-Increasing-Subsequence | :+1: | :+1: |  |  | :+1: |  |  |  |
 LongestPath |  |  |  |  | :+1: |  |  |  |


### PR DESCRIPTION
Adds a `LinearSearch()` function for Go with tests.

Already updated CONTRIBUTING.md from previous PR.